### PR TITLE
Atualiza lucro diário nos gráficos

### DIFF
--- a/StellaVisionMG_EXE_PATCH2_FIXED/StellaVisionMG_EXE_PATCH2_FIXED/StellaVisionMG/app.py
+++ b/StellaVisionMG_EXE_PATCH2_FIXED/StellaVisionMG_EXE_PATCH2_FIXED/StellaVisionMG/app.py
@@ -550,6 +550,19 @@ def conn():
     c.row_factory = sqlite3.Row
     return c
 
+
+def table_has_column(db: sqlite3.Connection, table: str, column: str) -> bool:
+    """Return True if the given SQLite table contains ``column``."""
+    try:
+        info = db.execute(f"PRAGMA table_info({table})").fetchall()
+    except sqlite3.OperationalError:
+        return False
+    for row in info:
+        name = row["name"] if isinstance(row, sqlite3.Row) else row[1]
+        if name == column:
+            return True
+    return False
+
 def br_money(v):
     if v is None: v = 0
     return f"R$ {v:,.2f}".replace(",", "X").replace(".", ",").replace("X", ".")
@@ -786,16 +799,33 @@ def compute_graphs(ini,fim,categoria,cidade,vendedor,incluir_rma, top_metric):
         m_labels = [r["cat"] for r in mc]
         m_values = [round((r["lucro"]/r["receita"]*100) if r["receita"] else 0,2) for r in mc]
 
-        # Vendas por dia (com zeros)
-        r30 = c.execute(f"""
-          SELECT date(s.data) AS d, SUM(si.qtde*si.preco_unit) v
-          FROM sale_items si JOIN sales s ON s.id=si.sale_id JOIN products p ON p.id=si.product_id
+        # Lucro líquido por dia (com zeros para dias sem venda)
+        item_expense_expr = "0"
+        if table_has_column(c, "sale_items", "despesas_variaveis"):
+            item_expense_expr = "COALESCE(si.despesas_variaveis, 0)"
+        lucro_rows = c.execute(
+            f"""
+          SELECT date(s.data) AS dia,
+                 SUM(
+                     COALESCE(si.preco_unit, si.preco_lista_snap, p.preco_lista, 0)
+                     - COALESCE(si.custo_snap, p.custo_base, 0)
+                     - {item_expense_expr}
+                 ) AS lucro_liquido
+          FROM sale_items si
+          JOIN sales s ON s.id = si.sale_id
+          JOIN products p ON p.id = si.product_id
           WHERE date(s.data) BETWEEN ? AND ? AND ({where})
           GROUP BY date(s.data)
-        """, [ult30_ini.isoformat(), fim.isoformat(), *params]).fetchall()
-        mapa30 = {row["d"]: row["v"] for row in r30}
-        labels30 = [ (ult30_ini + datetime.timedelta(days=i)).isoformat() for i in range(30) ]
-        valores30 = [round(mapa30.get(d,0),2) for d in labels30]
+          ORDER BY dia
+        """,
+            [ult30_ini.isoformat(), fim.isoformat(), *params],
+        ).fetchall()
+        lucro_por_dia = {row["dia"]: float(row["lucro_liquido"] or 0) for row in lucro_rows}
+        labels30 = date_range_labels(ult30_ini, fim)
+        valores30 = [round(lucro_por_dia.get(d, 0.0), 2) for d in labels30]
+        vendas_por_dia_lucro = [
+            {"data": d, "lucro_liquido": valores30[idx]} for idx, d in enumerate(labels30)
+        ]
 
         # Cidades vendidas
         rows_cid = c.execute(f"""
@@ -811,6 +841,7 @@ def compute_graphs(ini,fim,categoria,cidade,vendedor,incluir_rma, top_metric):
             "categoria": {"labels": cat_labels, "values": cat_values},
             "margem_categoria": {"labels": m_labels, "values": m_values},
             "vendas_dia": {"labels": labels30, "values": valores30},
+            "vendas_por_dia_lucro": vendas_por_dia_lucro,
             "cidades": {"labels": cid_labels, "values": cid_values}
         }
 

--- a/StellaVisionMG_EXE_PATCH2_FIXED/StellaVisionMG_EXE_PATCH2_FIXED/StellaVisionMG/templates/dashboard.html
+++ b/StellaVisionMG_EXE_PATCH2_FIXED/StellaVisionMG_EXE_PATCH2_FIXED/StellaVisionMG/templates/dashboard.html
@@ -85,6 +85,12 @@ async function fetchJSON(url){ const r = await fetch(url); return await r.json()
   const qs = {{ ('?' + request.query_string.decode())|tojson if request.query_string else '""' }};
   const charts = await fetchJSON("{{ url_for('api_graficos') }}" + qs);
 
+  const lucroDiarioApi = Array.isArray(charts.vendas_por_dia_lucro) ? charts.vendas_por_dia_lucro : [];
+  const lucroLabelsApi = lucroDiarioApi.map(item => item.data);
+  const lucroValuesApi = lucroDiarioApi.map(item => Number(item.lucro_liquido) || 0);
+  const vendasDiaLabelsFinal = lucroLabelsApi.length ? lucroLabelsApi : vendasDiaLabels;
+  const vendasDiaValuesFinal = lucroLabelsApi.length ? lucroValuesApi : vendasDiaValues;
+
   // ---------- TOP 10 ----------
   const ctx1 = document.getElementById('chartTop10');
   if (topMetric === 'faturamento' || topMetric === 'quantidade') {
@@ -112,7 +118,7 @@ async function fetchJSON(url){ const r = await fetch(url); return await r.json()
   const ctx4 = document.getElementById('chartVendasDia');
   new Chart(ctx4, {
     type: 'line',
-    data: { labels: vendasDiaLabels, datasets: [{ label: 'Lucro líquido diário (R$)', data: vendasDiaValues }] },
+    data: { labels: vendasDiaLabelsFinal, datasets: [{ label: 'Lucro líquido diário (R$)', data: vendasDiaValuesFinal }] },
     options: { responsive:true }
   });
 


### PR DESCRIPTION
## Summary
- ajusta `compute_graphs` para somar o lucro líquido diário com fallback para colunas opcionais e expõe a lista `vendas_por_dia_lucro`
- adiciona helper utilitário para verificar a existência de colunas na base antes de montar a query
- atualiza o dashboard para consumir o campo `lucro_liquido` retornado pela API ao montar o gráfico diário

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d156e9f28083339ebb4dce065e39ab